### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,9 @@ rvm:
   - 2.4.1
 gemfile:
   - gemfiles/gemfile
-  - gemfiles/fluentd.0.10.42.gemfile
 
 script: "bundle exec rake spec"
 
 branches:
   only:
     - master
-matrix:
-  exclude:
-    - rvm: 2.2
-      gemfile: gemfiles/fluentd.0.10.42.gemfile
-    - rvm: 2.3.4
-      gemfile: gemfiles/fluentd.0.10.42.gemfile
-    - rvm: 2.4.1
-      gemfile: gemfiles/fluentd.0.10.42.gemfile

--- a/fluent-plugin-fork.gemspec
+++ b/fluent-plugin-fork.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency "fluentd", [">= 0.10.0", "< 2"]
+  gem.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "coveralls"

--- a/gemfiles/fluentd.0.10.42.gemfile
+++ b/gemfiles/fluentd.0.10.42.gemfile
@@ -1,4 +1,0 @@
-source "http://rubygems.org"
-
-gem 'fluentd', '= 0.10.42'
-gemspec :path => '../'

--- a/lib/fluent/plugin/out_fork.rb
+++ b/lib/fluent/plugin/out_fork.rb
@@ -8,14 +8,6 @@ module Fluent::Plugin
 
     helpers :event_emitter
 
-    unless method_defined?(:log)
-      define_method(:log) { $log }
-    end
-
-    unless method_defined?(:router)
-      define_method(:router) { Fluent::Engine }
-    end
-
     def initialize
       super
     end

--- a/lib/fluent/plugin/out_fork.rb
+++ b/lib/fluent/plugin/out_fork.rb
@@ -1,8 +1,12 @@
-module Fluent
+require 'fluent/plugin/output'
+
+module Fluent::Plugin
   class ForkOutput < Output
     class MaxForkSizeError < StandardError; end
 
     Fluent::Plugin.register_output('fork', self)
+
+    helpers :event_emitter
 
     unless method_defined?(:log)
       define_method(:log) { $log }
@@ -33,7 +37,7 @@ module Fluent
       raise Fluent::ConfigError, "max_fallback must be one of #{fallbacks.inspect}" unless fallbacks.include?(@max_fallback)
     end
 
-    def emit(tag, es, chain)
+    def process(tag, es)
       es.each do |time, record|
         org_value = record[@fork_key]
         if org_value.nil?
@@ -76,8 +80,6 @@ module Fluent
       end
     rescue => e
       log.error "#{e.message}: #{e.backtrace.join(', ')}"
-    ensure
-      chain.next
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ require 'coveralls'
 Coveralls.wear!
 
 require 'fluent/test'
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 require 'fluent/plugin/out_fork'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Please take a look after #3 is merged.

I've tried to migrate to use v0.14 Output Plugin API.
In v0.14, Fluentd users will be able to switch non-buffered/buffered plugin by plugin configure.
Because v0.14 Output Plugin API is integrated in Fluent::Plugin::Output class.
We can choose this behavior with prefer_buffered_processing, process, and write APIs.

This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer https://docs.fluentd.org/v1.0/articles/plugin-update-from-v0.12 before release new version.

Thanks in advance.